### PR TITLE
Added check for humidity sensors to stop division by 0

### DIFF
--- a/smartapps/piratemedia/smartthings/virtual-thermostat-with-device.src/virtual-thermostat-with-device.groovy
+++ b/smartapps/piratemedia/smartthings/virtual-thermostat-with-device.src/virtual-thermostat-with-device.groovy
@@ -163,8 +163,12 @@ def getAverageHumidity() {
         count++
     }
     
-    //divide by number of sensors
-    return total / count
+    //only divide by number of sensors if there are more than 0
+    if(count > 0) {
+        return total / count
+    } else {
+        return 0
+    }
 }
 
 def switchOff(switches) {


### PR DESCRIPTION
I was noticing that when I added a Virtual Thermostat, it would pop up with an error message saying "An unexpected error occurred."

I looked at the IDE logs, and it was having an issue dividing in the Humidifier section when you didn't add a humidifier.

As a result, it was trying to divide by 0. So I just return 0 on `getAverageHumidity()` if there are 0 humidifier devices 😄 